### PR TITLE
[ISSUE-28] Add package specific documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ If you want to learn this tool directly from concrete, working examples we sugge
 2. [chain-status-example](https://github.com/lampajr/chain-status-example), a step by step simple example of how to integrate the tool.
 ## Technical information
 
-It is multipackage npm project. We recommend to use yarn, since just yarn.lock files are provided.
+It is multipackage npm project managed using *Lerna*.
+
+* **webpage**, providing a React web application (see [more details](./packages/webpage/README.md))
+* **action**, JS tool for the data generation (see [more details](./packages/action/README.md))
+
+We recommend to use yarn, since just yarn.lock files are provided.
 
 ### Available Scripts
 

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -1,0 +1,52 @@
+# Generate Data JS Tool 
+
+This package provides a JS tool which basically consumes information from Github API or Jenkins API and generates a JSON file which is retrieved by the [React web application](https://github.com/kiegroup/chain-status/tree/main/packages/webpage/README.md).
+
+## Usage
+
+This tool is an easy to use JS tool, in order to use you just need to install all required libraries, build the project and run the automatically generated distribution file at `packages/action/dist/index.js`.
+
+1. Install libraries [run it from the project's root]
+```bash
+$ yarn
+```
+
+2. Run the tool, this can be done either Command Line Interface approach (see [local dev](#local-execution) section) or using Github action (see [action flow](#action-flow) section)
+
+### Inputs
+
+In this section you can find overall list of inputs that you can or must provide to the tool, either using cli or using the Github workflow.
+
+| Field              | Required | Default             | Description                                                                                                                                                                                      |
+|--------------------|----------|---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| github-token       | true     |                     | The Github token that must be used to interact with Github API                                                                                                                                   |
+| definition-file    | true     |                     | The file containing all projects for which you want to provide the status, an [example](https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/main/.ci/pull-request-config.yaml) - more infos [here](https://github.com/kiegroup/build-chain-configuration-reader) |
+| title              | false    | Project status      | The project/webapp title                                                                                                                                                                         |
+| subtitle           | false    | Contribution status | The project/webapp subtitle                                                                                                                                                                      |
+| base-branch-filter | false    |                     | A comma separated list of base branches RegEx to be filtered. Like `main,7.59.x,8.x` or `main,^7.*`                                                                                              |
+| project-filter     | false    |                     | A comma separated list of project RegEx to be filtered. Like `drools,opta.*` or `jbpm,^drools.*`                                                                                                 |
+| created-by         | false    | github action       | The user/machine/whatever that regenerates the report                                                                                                                                            |
+| created-url        | false    |                     | Normally the job generating the info URL                                                                                                                                                         |
+| logger-level       | false    | info                | The log level. 'info' (default) \| 'trace' \| 'debug'                                                                                                                                            |
+| gh-pages-branch    | false    | gh-pages            | The branch used by `gh-pages` tool, where the webpage will be stored                                                                                                                             |
+
+
+### Local Execution
+
+In order to locally run this, you simply need to run the [cli tool](./src/bin/cli.js) providing at least all required arguments (more details in [inputs](#inputs) section)
+
+Here an usage example:
+
+```bash
+$ node packages/action/src/bin/cli.js -t 'Title' -st 'Subtitle' --token <GH-TOKEN> -df https://raw.githubusercontent.com/kiegroup/kogito-pipelines/main/.ci/pull-request-config.yaml [-o <PATH-TO-REACT-WEBAPP-DATA>]
+```
+
+### Action Flow
+
+This tool can be integrated in a Github action in order to automate the data generation process, for this purpose this project comes with an easy to use [Github action](https://github.com/kiegroup/chain-status/blob/main/.ci/actions/generate-data/action.yml) that you only need to use in your own Github workflows.
+
+Here the main important steps performed by **generate-data** action:
+
+1. Checkout in the branch where you want to store the webpage code and content, the default is `gh-pages`.
+2. Execute the [chain-status](https://github.com/kiegroup/chain-status/tree/main/packages/action/dist/index.js) tool that, given a set of inputs, compute the configuration files and all the contents that are used by the webpage - this execution is performed using another [Github action](https://github.com/kiegroup/chain-status/blob/main/action.yml).
+3. Commit and push the newly generated data in the target branch (e.g., `gh-pages`).

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -1,10 +1,14 @@
 # Generate Data JS Tool 
 
-This package provides a JS tool which basically consumes information from Github API or Jenkins API and generates a JSON file which is retrieved by the [React web application](https://github.com/kiegroup/chain-status/tree/main/packages/webpage/README.md).
+This package provides a NodeJS CLI tool which basically consumes information from Github API and/or Jenkins API and generates a JSON file which is retrieved by the [React web application](https://github.com/kiegroup/chain-status/tree/main/packages/webpage/README.md).
 
 ## Usage
 
-This tool is an easy to use JS tool, in order to use you just need to install all required libraries, build the project and run the automatically generated distribution file at `packages/action/dist/index.js`.
+This tool can be easy use as a NodeJS CLI tool or as a Github Action
+
+### NodeJS CLI Usage
+
+In order to use you just need to install all required libraries, build the project and run the automatically generated distribution file at `packages/action/dist/index.js`.
 
 1. Install libraries [run it from the project's root]
 ```bash
@@ -41,7 +45,7 @@ Here an usage example:
 $ node packages/action/src/bin/cli.js -t 'Title' -st 'Subtitle' --token <GH-TOKEN> -df https://raw.githubusercontent.com/kiegroup/kogito-pipelines/main/.ci/pull-request-config.yaml [-o <PATH-TO-REACT-WEBAPP-DATA>]
 ```
 
-### Action Flow
+### Github Action Flow
 
 This tool can be integrated in a Github action in order to automate the data generation process, for this purpose this project comes with an easy to use [Github action](https://github.com/kiegroup/chain-status/blob/main/.ci/actions/generate-data/action.yml) that you only need to use in your own Github workflows.
 

--- a/packages/webpage/README.md
+++ b/packages/webpage/README.md
@@ -1,6 +1,64 @@
-# Chain Status webpage Technical Information
+# Project Status Web Page
 
-## Lazy loading
+This package contains the source code of React web application.
+
+The look and feel of this web application mainly relies on the [Ant Design](https://ant.design/docs/react/introduce) React library, which provides a set of high quality components for building rich, interactive user interfaces.
+
+## Local Development
+
+If you want to build or contribute to this project you will probably need to build/run this web application locally, here few steps to follow:
+
+1. Clone the repository
+```bash
+$ git clone git@github.com:kiegroup/chain-status.git
+```
+
+2. Install all libraries [run it in the project's root]
+```bash
+$ yarn
+```
+
+3. Run the application in development mode [run it in the `webpage` package]
+```bash
+$ yarn run
+```
+Open [http://localhost:3000](http://localhost:3000) to view it in the browser.\
+Keep in mind that the page will reload if you make edits on the source code.
+
+4. Build the whole project [run it on the project's root]
+```bash
+$ yarn build
+```
+
+## Action Flow
+
+If you want to install this web application on your repository in an automated way, this project comes with an easy to use [Github action](https://github.com/kiegroup/chain-status/blob/main/.ci/actions/generate-app/action.yml) that you can use on your Github workflows.
+
+
+The **generate-app** action is in charge to checkout this project, build it using `yarn` and publish it on a specific branch of the repository is including it.
+
+### Action Steps
+Here the main important steps performed by **generate-app** action:
+
+1. Checkout in the branch where you want to store the webpage code and content, the default is `gh-pages`. [the first time you run this action there will be no webpage]
+2. Checkout in the original [chain-status](https://github.com/kiegroup/chain-status) repository, i.e., this one.
+3. Setup nodejs and build the webpage using `yarn`.
+4. Check if in the target branch (e.g., `gh-pages`) there are old content/configuration files by checking the `data/` folder. If there exists, it copies its content under the newly compiled webpage (under `./packages/webpage/public/`).
+5. Deploy the created page using [gh-pages](https://www.npmjs.com/package/gh-pages) tool in the target branch (e.g., `gh-pages`).
+
+
+### Inputs
+
+| Field           | Required | Default  | Description                                                          |
+|-----------------|----------|----------|----------------------------------------------------------------------|
+| github-token    | true     |          | The Github token that must be used to interact with Github API       |
+| info-md-url     | true     |          | The url pointing to a Markdown file used to populate info section    |
+| gh-pages-branch | false    | gh-pages | The branch used by `gh-pages` tool, where the webpage will be stored |
+
+## Technical Information
+
+### Lazy loading
+
 1. I use redux to handle states. sectionsShow specifically https://github.com/kiegroup/chain-status/blob/main/packages/webpage/src/service/layout.service.tsx#L43
 
 2. Then section is only shown based on the state https://github.com/kiegroup/chain-status/blob/f891b11cfedfc8c10143a2c7f7c1d0afd5a7bc0f/packages/webpage/src/components/pullrequests/List.tsx#L21

--- a/packages/webpage/README.md
+++ b/packages/webpage/README.md
@@ -1,6 +1,7 @@
 # Project Status Web Page
 
-This package contains the source code of React web application.
+This package contains the source code of React web application. The web application has to be instantiated by your own configuration like information page markdown file. 
+The data consumed by the app is preprocessed by [action package](https://github.com/kiegroup/chain-status/tree/main/packages/action) so no need for a backend and can be easily published on services like Github Packages.
 
 The look and feel of this web application mainly relies on the [Ant Design](https://ant.design/docs/react/introduce) React library, which provides a set of high quality components for building rich, interactive user interfaces.
 
@@ -30,7 +31,7 @@ Keep in mind that the page will reload if you make edits on the source code.
 $ yarn build
 ```
 
-## Action Flow
+## Installation
 
 If you want to install this web application on your repository in an automated way, this project comes with an easy to use [Github action](https://github.com/kiegroup/chain-status/blob/main/.ci/actions/generate-app/action.yml) that you can use on your Github workflows.
 


### PR DESCRIPTION
**Thank you for submitting this pull request**

fix:
- https://github.com/kiegroup/chain-status/issues/28

**referenced Pull Requests**: 
- https://github.com/kiegroup/chain-status/pull/31
- https://github.com/kiegroup/chain-status/pull/34

Add package specific documentation:

- `webpage` documentation which includes specification and usage of its related `generate-app` action.
- `action` documentation which provides the js tool purpose and usage, either from command line or using `generate-data` action.
