### PR TITLE
using yarn instead of npm

### DIFF
--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-node@v4
         with:          
           node-version: 20
-      - run: npm ci
+      - run: yarn install --frozen-lockfile        
       - run: npm run test:report
       - run: sonar-scanner
           -Dsonar.organization=kiegroup


### PR DESCRIPTION
**Thank you for submitting this pull request**

fix #56 

the upgrade and `npm ci' requires to use npm lock files, but this repo uses yarn rather npm so replacing that command.

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

- https://github.com/kiegroup/chain-status/pull/58
- https://github.com/kiegroup/chain-status/pull/57
