### PR TITLE
Upgraded actions/checkout to latest version to not warn about old Nodejs

### DIFF
--- a/.ci/actions/generate-app/action.yml
+++ b/.ci/actions/generate-app/action.yml
@@ -29,11 +29,11 @@ runs:
         path: ./current-project
         ref: ${{ inputs.gh-pages-branch }}
     - name: Checkout chain-status repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: kiegroup/chain-status
         path: ./chain-status
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v4
       with:
         node-version: 20
         registry-url: https://registry.npmjs.org/

--- a/.ci/actions/generate-app/action.yml
+++ b/.ci/actions/generate-app/action.yml
@@ -35,7 +35,7 @@ runs:
         path: ./chain-status
     - uses: actions/setup-node@v1
       with:
-        node-version: 14
+        node-version: 20
         registry-url: https://registry.npmjs.org/
     - run: yarn
       shell: bash

--- a/.ci/actions/generate-data/action.yml
+++ b/.ci/actions/generate-data/action.yml
@@ -47,7 +47,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout chain-status repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: ./chain-status
         ref: ${{ inputs.gh-pages-branch }}

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ inputs:
     description: "A comma separated list of branches to compare. Like `main,8.30.x,8.29.x`"
     required: false
 runs:
-  using: "node16"
+  using: "node20"
   main: "packages/action/dist/index.js"
 branding:
   icon: "box"


### PR DESCRIPTION
**Thank you for submitting this pull request**

fixing 
```

* Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2, kiegroup/chain-status@main. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
* The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

**referenced Pull Requests**:

- maybe related ? https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2522
